### PR TITLE
add new "warn" rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,12 @@ module.exports = {
     'camelcase': 'warn',
     'comma-dangle': ['warn', 'always-multiline'],
     'no-process-exit': 'warn',
+    'arrow-spacing': 'warn',
+    'space-before-blocks': 'warn',
+    'keyword-spacing': 'warn',
+    "indent": ['warn', 2, {"SwitchCase": 1}],
+    "key-spacing": ['warn', {"beforeColon": false, "afterColon": true, "mode": "minimum"}],
+    "comma-spacing": ['warn', { "before": false, "after": true }],
 
     // error
     'no-var': 'error',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-relayr",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-relayr",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "description": "eslint config for relayr",
   "main": "index.js",
   "keywords": [


### PR DESCRIPTION
Added more rules, as "warn" level.

These will not fail `npm run lint` command but only show the warning. When we have all the services updated according to these rules, we'll make them required.